### PR TITLE
:bug: Fixes spelling error and incorrect command.

### DIFF
--- a/rounds/_r001/031_vim-search-then-find-and-replace.md
+++ b/rounds/_r001/031_vim-search-then-find-and-replace.md
@@ -41,7 +41,7 @@ tweet:
 [heading__syntax]: #syntax
 
 
-Search current line for `__search__`, then find pattern `__find__` and replace with `__repalce__` syntax...
+Search current line for `__search__`, then find pattern `__find__` and replace with `__replace__` syntax...
 
 
 ```vim

--- a/rounds/_r001/053_vim-precise-motions.md
+++ b/rounds/_r001/053_vim-precise-motions.md
@@ -40,7 +40,7 @@ But these motions are all relative to the initial cursor position, to instead mo
 
 - <kbd>5</kbd><kbd>G</kbd> moves the cursor to the fifth line of current buffer/file
 
-- <kbd>G</kbd><kbd>G</kbd> moves the cursor to the first line of current buffer/file
+- <kbd>g</kbd><kbd>g</kbd> moves the cursor to the first line of current buffer/file
 
 
 **Column Motions**


### PR DESCRIPTION
**Fixes**

- `031_vim-search-then-find-and-replace.md` file, fixed spelling error from repalce to replace

- `053_vim-precise-motions.md` file, fixed wrong command from GG to gg for "goto line N (default: first line), on the first non-blank character"
